### PR TITLE
Remove building:levels in imported tags

### DIFF
--- a/mappings_csv/Specific_1.csv
+++ b/mappings_csv/Specific_1.csv
@@ -1,6 +1,6 @@
 SpecificUs,osm_key2,osm_val2
-4 Stories or Less,building:levels,<4
-5 Stories or More,building:levels,>4
+4 Stories or Less,,
+5 Stories or More,,
 Adult Care Facility - Social and Recreational Services,,
 Adult Day Services - Skilled Care Services Offered,,
 Amusement Facility,,


### PR DESCRIPTION
Related to https://github.com/osmlab/labuildings/issues/64, this PR removes `building:levels` tag. Sample data is included.  I also edited the [OSM wiki](http://wiki.openstreetmap.org/w/index.php?title=Los_angeles%2C_California%2FBuildings_Import&type=revision&diff=1287154&oldid=1286552).
