### PR TITLE
remove confusing "manually merge layers together"

### DIFF
--- a/IMPORTING.md
+++ b/IMPORTING.md
@@ -61,7 +61,6 @@ To contribute to this project, you need to use the JOSM editor.  Here are some r
   * Switch to the OSM layer.
   * Select the building, paste the tags.
 
-* Manually merge the layers together. 
 * If the imported data are of higher quality, select both buildings and use the **Replace geometry** tool. 
  
  ![replace](https://cloud.githubusercontent.com/assets/353700/12942518/ddba87a4-d001-11e5-9441-2561f67b45bc.gif) 


### PR DESCRIPTION
This sentence confused me when I was reading it for the first time. What
does it mean to "manually merge layers together"?

Maybe it's intended to be a header for the following paragraphs, but
it's not styled as such and actually, it's explained pretty well farther
down the document, so I think it's all together better with it removed.