### PR TITLE
Add more tags to fix #95

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,16 +71,3 @@ directories:
 	mkdir -p chunks
 	mkdir -p merged
 	mkdir -p osm
-
-# Make TileMill 1 project
-tilemill:
-	mkdir -p ${HOME}/Documents/MapBox/project
-	ln -sf "`pwd`" ${HOME}/Documents/MapBox/project/labuildings
-
-# Load database for Mapbox Studio
-database: AddressPt/addresses.shp BldgPly/buildings.shp BlockGroupPly/blockgroups.shp
-	createdb labuildings
-	psql labuildings -c "CREATE EXTENSION postgis;"
-	shp2pgsql AddressPt/address.shp | psql labuildings
-	shp2pgsql BldgPly/buildings.shp | psql labuildings
-	shp2pgsql BlockGroupPly/blockgroups.shp | psql labuildings

--- a/mappings_csv/Specific_1.csv
+++ b/mappings_csv/Specific_1.csv
@@ -18,7 +18,7 @@ Church Parking Lot,,
 "Commercial Swimming Pools, School",,
 Concessions,,
 Contractor Storage Yard,building:use,storage_yard
-"Convalescent Hospital, Nursing Home",amenity,social_facility,social_facility,assisted_living,social_facility,day_care
+"Convalescent Hospital, Nursing Home",amenity,social_facility,social_facility,assisted_living
 Dance Hall,building:use,dance_hall
 Detached,,
 "Discount Department Store (Target, etc.)",,

--- a/osm_tags.py
+++ b/osm_tags.py
@@ -26,8 +26,8 @@ def csv_to_json(mapping_name, csv_file):
                     mappings[mapping_name][row[0]]['val2'] = row[4]; 
             if len(row) > 6:
                 if row[5] != '' and row[6] != '':
-                    mappings[mapping_name][row[0]]['key3'] = row[4];
-                    mappings[mapping_name][row[0]]['val3'] = row[5]; 
+                    mappings[mapping_name][row[0]]['key3'] = row[5];
+                    mappings[mapping_name][row[0]]['val3'] = row[6]; 
     # print mappings
 
 csv_to_json('GeneralUse', GENERAL_USE_CSV)

--- a/osm_tags.py
+++ b/osm_tags.py
@@ -20,18 +20,14 @@ def csv_to_json(mapping_name, csv_file):
                 'key1': row[1],
                 'val1': row[2]
             }
-            if len(row) == 5:
+            if len(row) > 4:
                 if row[3] != '' and row[4] != '':
-                    mappings[mapping_name][row[0]] = {
-                        'key2': row[3],
-                        'val2': row[4]
-                    }
-            if len(row) == 7:
+                    mappings[mapping_name][row[0]]['key2'] = row[3];
+                    mappings[mapping_name][row[0]]['val2'] = row[4]; 
+            if len(row) > 6:
                 if row[5] != '' and row[6] != '':
-                    mappings[mapping_name][row[0]] = {
-                        'key3': row[4],
-                        'val3': row[5]
-                    }
+                    mappings[mapping_name][row[0]]['key3'] = row[4];
+                    mappings[mapping_name][row[0]]['val3'] = row[5]; 
     # print mappings
 
 csv_to_json('GeneralUse', GENERAL_USE_CSV)
@@ -50,7 +46,15 @@ def get_osm_tags(feature):
     for o in order:
         if props.has_key(o) and props[o] is not None:
             if mappings[o].has_key(props[o]):
-                key = mappings[o][props[o]]['key1']
-                val = mappings[o][props[o]]['val1']
-                osm_tags[key] = val
+                key1 = mappings[o][props[o]]['key1']
+                val1 = mappings[o][props[o]]['val1']
+                osm_tags[key1] = val1
+                if mappings[o][props[o]].has_key('key2'):
+                  key2 = mappings[o][props[o]]['key2']
+                  val2 = mappings[o][props[o]]['val2']
+                  osm_tags[key2] = val2
+                if mappings[o][props[o]].has_key('key3'):
+                  key3 = mappings[o][props[o]]['key3']
+                  val3 = mappings[o][props[o]]['val3']
+                  osm_tags[key3] = val3
     return osm_tags


### PR DESCRIPTION
This updates the `osm_tags.py` based on initial work by @jschleuss expanding more tags from the Specific_1.csv.  The current implementation checks for additional key/value pairs and updates the osm file.  This is not a very elegant solution but works for now.  In the future, we need to improve the script to parse any number of key/value pairs instead of manually updating the script every time we add more tags.

Sample is included and the rebuild of import data is running as I write this.

Ticket: https://github.com/osmlab/labuildings/issues/95